### PR TITLE
Feature: improve CLI output

### DIFF
--- a/attacks/attack.go
+++ b/attacks/attack.go
@@ -2,8 +2,8 @@ package attacks
 
 import (
 	"bytes"
-	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -15,7 +15,7 @@ import (
 var client_body *http.Client
 
 func makeHandshake() {
-	fmt.Println("New connection made!!!")
+	slog.Debug("New connection made... \n")
 	client_body = &http.Client{}
 }
 
@@ -47,7 +47,7 @@ func makeRequest(opts Options, wg *sync.WaitGroup, resp_results chan<- rs.Result
 	resp, err := client_body.Do(req)
 	elapsed := time.Since(start)
 	if err != nil {
-		fmt.Printf("Error_2:  %v\n", err)
+		// fmt.Printf("Error_2:  %v\n", err)
 		resp_results <- rs.Result{Error: err}
 		return
 	}

--- a/attacks/basic.go
+++ b/attacks/basic.go
@@ -1,7 +1,6 @@
 package attacks
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -34,7 +33,5 @@ func BasicAttack(opts Options) rs.PResultIn {
 		results = append(results, result)
 	}
 	sc := sr.ShowResults(results, opts.Requests, "basic", opts.Method)
-	fmt.Printf("%+v\n", sc)
-
 	return rs.PResultIn{PRes: sc, NRes: results}
 }

--- a/attacks/burst.go
+++ b/attacks/burst.go
@@ -1,7 +1,6 @@
 package attacks
 
 import (
-	"fmt"
 	"sync"
 
 	// pr "github.com/Mujib-Ahasan/Suzi/cmd"
@@ -28,6 +27,5 @@ func BurstAttack(opts Options) rs.PResultIn {
 		results = append(results, r)
 	}
 	sc := sr.ShowResults(results, opts.Requests, "burst", opts.Method)
-	fmt.Printf("%+v\n", sc)
 	return rs.PResultIn{PRes: sc, NRes: results}
 }

--- a/attacks/option.go
+++ b/attacks/option.go
@@ -3,13 +3,14 @@ package attacks
 import "time"
 
 type Options struct {
-	URL         string
-	Rate        int
-	Requests    int
-	Timeout     time.Duration
-	Type        string
-	Method      string
-	Body        []byte
-	ContentType string
-	Headers     map[string]string
+	URL          string
+	Rate         int
+	Requests     int
+	Timeout      time.Duration
+	Type         string
+	Method       string
+	Body         []byte
+	ContentType  string
+	Headers      map[string]string
+	EmailEnabled bool
 }

--- a/attacks/rampUp.go
+++ b/attacks/rampUp.go
@@ -1,7 +1,6 @@
 package attacks
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -39,6 +38,5 @@ func RampUpAttack(opts Options, startRate int, peakRate int) rs.PResultIn {
 	}
 
 	sc := sr.ShowResults(results, opts.Requests, "rampup", opts.Method)
-	fmt.Printf("%+v\n", sc)
 	return rs.PResultIn{PRes: sc, NRes: results}
 }

--- a/attacks/randomLoad.go
+++ b/attacks/randomLoad.go
@@ -1,7 +1,6 @@
 package attacks
 
 import (
-	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -28,6 +27,5 @@ func RandomLoadAttack(opts Options) rs.PResultIn {
 		results = append(results, result)
 	}
 	sc := sr.ShowResults(results, opts.Requests, "random", opts.Method)
-	fmt.Printf("%+v\n", sc)
 	return rs.PResultIn{PRes: sc, NRes: results}
 }

--- a/attacks/run.go
+++ b/attacks/run.go
@@ -2,6 +2,7 @@ package attacks
 
 import (
 	"fmt"
+	"log/slog"
 
 	rs "github.com/Mujib-Ahasan/Suzi/common"
 )
@@ -9,27 +10,33 @@ import (
 func Run(opts Options, mail bool) []rs.PlotC {
 	var attackAll []rs.PlotC
 	if mail {
-		attackAll = append(attackAll, rs.PlotC{Results: BasicAttack(opts)})
-		attackAll = append(attackAll, rs.PlotC{Results: BurstAttack(opts)})
-		attackAll = append(attackAll, rs.PlotC{Results: RampUpAttack(opts, 1, 15)})
-		attackAll = append(attackAll, rs.PlotC{Results: RandomLoadAttack(opts)})
+		slog.Debug("All Attack at once! Starting... \n")
+		attackAll = append(attackAll, rs.PlotC{Attack: "basic", Results: BasicAttack(opts)})
+		attackAll = append(attackAll, rs.PlotC{Attack: "burst", Results: BurstAttack(opts)})
+		attackAll = append(attackAll, rs.PlotC{Attack: "rampup", Results: RampUpAttack(opts, 1, 15)})
+		attackAll = append(attackAll, rs.PlotC{Attack: "random", Results: RandomLoadAttack(opts)})
 		return attackAll
 	}
 
 	switch opts.Type {
 	case "all":
-		attackAll = append(attackAll, rs.PlotC{Results: BasicAttack(opts)})
-		attackAll = append(attackAll, rs.PlotC{Results: BurstAttack(opts)})
-		attackAll = append(attackAll, rs.PlotC{Results: RampUpAttack(opts, 1, 15)})
-		attackAll = append(attackAll, rs.PlotC{Results: RandomLoadAttack(opts)})
+		slog.Debug("All Attack at once! Starting... \n")
+		attackAll = append(attackAll, rs.PlotC{Attack: "basic", Results: BasicAttack(opts)})
+		attackAll = append(attackAll, rs.PlotC{Attack: "burst", Results: BurstAttack(opts)})
+		attackAll = append(attackAll, rs.PlotC{Attack: "rampup", Results: RampUpAttack(opts, 1, 15)})
+		attackAll = append(attackAll, rs.PlotC{Attack: "random", Results: RandomLoadAttack(opts)})
 	case "basic":
-		attackAll = append(attackAll, rs.PlotC{Results: BasicAttack(opts)})
+		slog.Debug("Basic Attack! Starting... \n")
+		attackAll = append(attackAll, rs.PlotC{Attack: "basic", Results: BasicAttack(opts)})
 	case "burst":
-		attackAll = append(attackAll, rs.PlotC{Results: BurstAttack(opts)})
+		slog.Debug("Burst Attack! Starting... \n")
+		attackAll = append(attackAll, rs.PlotC{Attack: "burst", Results: BurstAttack(opts)})
 	case "rampup":
-		attackAll = append(attackAll, rs.PlotC{Results: RampUpAttack(opts, 1, 15)})
+		slog.Debug("Rampup Attack! Starting... \n")
+		attackAll = append(attackAll, rs.PlotC{Attack: "rampup", Results: RampUpAttack(opts, 1, 15)})
 	case "random":
-		attackAll = append(attackAll, rs.PlotC{Results: RandomLoadAttack(opts)})
+		slog.Debug("Random Attack! Starting... \n")
+		attackAll = append(attackAll, rs.PlotC{Attack: "random", Results: RandomLoadAttack(opts)})
 	default:
 		return []rs.PlotC{
 			{Results: rs.PResultIn{

--- a/cmd/attack.go
+++ b/cmd/attack.go
@@ -1,14 +1,30 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var quiet bool
+var verbose bool
 
 var attackCmd = &cobra.Command{
 	Use:   "attack",
 	Short: "HTTP load testing related subcommands",
 	Long:  "Run HTTP load tests and send reports.",
+
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if quiet && verbose {
+			return fmt.Errorf("cannot use --quiet and --verbose together")
+		}
+		return nil
+	},
 }
 
 func init() {
 	rootCmd.AddCommand(attackCmd)
 
+	attackCmd.PersistentFlags().BoolVar(&quiet, "quiet", false, "machine-friendly output")
+	attackCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "human-friendly output")
 }

--- a/cmd/attack_apply.go
+++ b/cmd/attack_apply.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -47,7 +48,7 @@ as the primary configuration source. CLI flags override YAML values.`,
 		if err != nil {
 			return err
 		}
-		payload, err := currentAttack.ValidateBody()
+		payload, err := cfg.ValidateBody()
 		if err != nil {
 			return err
 		}
@@ -56,17 +57,28 @@ as the primary configuration source. CLI flags override YAML values.`,
 		if err != nil {
 			return err
 		}
+		emailFlag := false
+
+		if cfg.Email != nil {
+			emailFlag = true
+		}
 
 		opts := attacks.Options{
-			URL:         cfg.AttackURL,
-			Rate:        cfg.AttackRate,
-			Requests:    cfg.AttackReq,
-			Timeout:     cfg.AttackTimeout,
-			Type:        cfg.AttackType,
-			Method:      cfg.AttackMethod,
-			Body:        payload,
-			ContentType: attackContentType,
+			URL:          cfg.AttackURL,
+			Rate:         cfg.AttackRate,
+			Requests:     cfg.AttackReq,
+			Timeout:      cfg.AttackTimeout,
+			Type:         cfg.AttackType,
+			Method:       cfg.AttackMethod,
+			Body:         payload,
+			ContentType:  attackContentType,
+			EmailEnabled: emailFlag,
 		}
+
+		if verbose {
+			printVerboseHeader(opts)
+		}
+		slog.Debug("Preparing for attack ")
 		var attackList []common.PlotC
 		var mailCfg ml.Config
 		if cfg.Email == nil {
@@ -85,6 +97,18 @@ as the primary configuration source. CLI flags override YAML values.`,
 				Retries:     cfg.Email.SMTP.Retries,
 			}
 		}
+
+		switch {
+		case quiet:
+			printQuiet(attackList)
+
+		case verbose:
+			printVerbose(attackList)
+
+		default:
+			printDefault(attackList)
+		}
+
 		if err := attackList[0].Results.Err; err != nil {
 			return fmt.Errorf("error: %v ", err)
 		}
@@ -106,6 +130,7 @@ func init() {
 }
 
 func loadAttackFromYAML(path string) (*Attack, error) {
+	slog.Debug("Parsing YAML file")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
@@ -120,6 +145,7 @@ func loadAttackFromYAML(path string) (*Attack, error) {
 }
 
 func (cAttack Attack) ValidateYaml() error {
+	slog.Debug("Validating YAML file")
 
 	if strings.TrimSpace(cAttack.AttackURL) == "" {
 		return fmt.Errorf("url is required")
@@ -167,6 +193,7 @@ func (cAttack Attack) ValidateYaml() error {
 }
 
 func (e *EmailConfig) Validate() error {
+	slog.Debug("Validating Email details \n")
 	if strings.TrimSpace(e.To) == "" {
 		return fmt.Errorf("email.to is required")
 	}

--- a/cmd/attack_email.go
+++ b/cmd/attack_email.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -65,27 +66,34 @@ var attackEmailCmd = &cobra.Command{
 		header := currentAttack.ValidateHeader()
 
 		opts := attacks.Options{
-			URL:         currentAttack.AttackURL,
-			Rate:        currentAttack.AttackRate,
-			Requests:    currentAttack.AttackReq,
-			Timeout:     currentAttack.AttackTimeout,
-			Type:        currentAttack.AttackType,
-			Method:      currentAttack.AttackMethod,
-			Body:        payload,
-			ContentType: attackContentType,
-			Headers:     header,
+			URL:          currentAttack.AttackURL,
+			Rate:         currentAttack.AttackRate,
+			Requests:     currentAttack.AttackReq,
+			Timeout:      currentAttack.AttackTimeout,
+			Type:         currentAttack.AttackType,
+			Method:       currentAttack.AttackMethod,
+			Body:         payload,
+			ContentType:  attackContentType,
+			Headers:      header,
+			EmailEnabled: true,
 		}
 
-		fmt.Println("Email command invoked with:")
-		fmt.Println("SMTP Host:", currentAttack.SmtpHost)
-		fmt.Println("SMTP Port:", currentAttack.SmtpPort)
-		fmt.Println("SMTP User:", currentAttack.SmtpUser)
-		fmt.Println("SMTP TLS:", currentAttack.SmtpTLS)
-		fmt.Println("Retries:", currentAttack.SmtpRetries)
-		fmt.Println("Body:", currentAttack.AttackBody)
-		fmt.Println("content-type:", attackContentType)
+		if verbose {
+			printVerboseHeader(opts)
+		}
 
 		attackList := attacks.Run(opts, true)
+
+		switch {
+		case quiet:
+			printQuiet(attackList)
+
+		case verbose:
+			printVerbose(attackList)
+
+			// default:
+			// 	printDefault(attackList)
+		}
 
 		if err := attackList[0].Results.Err; err != nil {
 			return fmt.Errorf("error: %v ", err)
@@ -128,6 +136,7 @@ func ValidateContentType(ct string) (string, error) {
 }
 
 func (cAttack Attack) ValidateHeader() map[string]string {
+	slog.Debug("Validating header")
 	headers := make(map[string]string)
 	if strings.TrimSpace(cAttack.Header) == "" {
 		return headers

--- a/cmd/attack_run.go
+++ b/cmd/attack_run.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -54,27 +55,34 @@ Example:
 		header := currentAttack.ValidateHeader()
 
 		opts := attacks.Options{
-			URL:         currentAttack.AttackURL,
-			Rate:        currentAttack.AttackRate,
-			Requests:    currentAttack.AttackReq,
-			Timeout:     currentAttack.AttackTimeout,
-			Type:        currentAttack.AttackType,
-			Method:      currentAttack.AttackMethod,
-			Body:        payload,
-			ContentType: attackContentType,
-			Headers:     header,
+			URL:          currentAttack.AttackURL,
+			Rate:         currentAttack.AttackRate,
+			Requests:     currentAttack.AttackReq,
+			Timeout:      currentAttack.AttackTimeout,
+			Type:         currentAttack.AttackType,
+			Method:       currentAttack.AttackMethod,
+			Body:         payload,
+			ContentType:  attackContentType,
+			Headers:      header,
+			EmailEnabled: false,
 		}
-		fmt.Printf("Starting attack: \n")
-		fmt.Printf("  URL: %s\n", opts.URL)
-		fmt.Printf("  Rate: %d RPS\n", opts.Rate)
-		fmt.Printf("  Requests: %d\n", opts.Requests)
-		fmt.Printf("  Timeout: %s\n", opts.Timeout)
-		fmt.Printf("  Attack Type: %s\n", opts.Type)
-		fmt.Printf("  Method: %s\n", opts.Method)
-		fmt.Printf(" Body: %s \n", opts.Body)
-		fmt.Printf("content type: %s \n", opts.ContentType)
 
+		if verbose {
+			printVerboseHeader(opts)
+		}
+		slog.Debug("Preparing for attack")
 		attackList := attacks.Run(opts, false)
+
+		switch {
+		case quiet:
+			printQuiet(attackList)
+
+		case verbose:
+			printVerbose(attackList)
+
+			// default:
+			// 	printDefault(attackList)
+		}
 
 		if err := attackList[0].Results.Err; err != nil {
 			return fmt.Errorf("error: %v ", err)
@@ -112,11 +120,13 @@ func init() {
 }
 
 func (cAttack Attack) ValidateJSON(data []byte) error {
+	slog.Debug("Validating JSON")
 	var js json.RawMessage
 	return json.Unmarshal(data, &js)
 }
 
 func (cAttack Attack) ValidateMethod() error {
+	slog.Debug("Validating attacking method")
 	methods := [...]string{"POST", "GET", "PUT", "DELETE", "PATCH"}
 	for _, e := range methods {
 		if e == cAttack.AttackMethod {
@@ -127,21 +137,21 @@ func (cAttack Attack) ValidateMethod() error {
 }
 
 func (cAttack Attack) ValidateBody() ([]byte, error) {
+	slog.Debug("Validating body")
 	var payload []byte
-	if currentAttack.AttackMethod != "GET" && currentAttack.AttackBody != "" {
-		payload = []byte(currentAttack.AttackBody)
+	if cAttack.AttackMethod != "GET" && cAttack.AttackBody != "" {
+		payload = []byte(cAttack.AttackBody)
 	}
 
-	if currentAttack.AttackMethod != "GET" && currentAttack.AttackBodyFile != "" {
-		b, err := os.ReadFile(currentAttack.AttackBodyFile)
+	if cAttack.AttackMethod != "GET" && cAttack.AttackBodyFile != "" {
+		b, err := os.ReadFile(cAttack.AttackBodyFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read Body file: %w", err)
 		}
 		payload = b
 	}
-	if len(payload) > 0 && currentAttack.AttackMethod != "GET" {
-		err := currentAttack.ValidateJSON(payload)
-		fmt.Printf("body: %s ", string(payload))
+	if len(payload) > 0 && cAttack.AttackMethod != "GET" {
+		err := cAttack.ValidateJSON(payload)
 		if err != nil {
 			return nil, fmt.Errorf("JSON provided is not valid")
 		}
@@ -152,12 +162,12 @@ func (cAttack Attack) ValidateBody() ([]byte, error) {
 
 func (cAttack Attack) ValidateBeforeAttack() error {
 
-	if currentAttack.AttackBody != "" && currentAttack.AttackBodyFile != "" {
+	if cAttack.AttackBody != "" && cAttack.AttackBodyFile != "" {
 		return fmt.Errorf("both attackBody and attackBodyFile cannot be set")
 	}
 
-	if (currentAttack.AttackMethod == "PUT" || currentAttack.AttackMethod == "POST" || currentAttack.AttackMethod == "PATCH") && (currentAttack.AttackBody == "" && currentAttack.AttackBodyFile == "") {
-		return fmt.Errorf("%s requires a Body", currentAttack.AttackMethod)
+	if (cAttack.AttackMethod == "PUT" || cAttack.AttackMethod == "POST" || cAttack.AttackMethod == "PATCH") && (cAttack.AttackBody == "" && cAttack.AttackBodyFile == "") {
+		return fmt.Errorf("%s requires a Body", cAttack.AttackMethod)
 	}
 
 	return nil

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/Mujib-Ahasan/Suzi/attacks"
+	"github.com/Mujib-Ahasan/Suzi/common"
+)
+
+func printQuiet(s []common.PlotC) {
+	for _, e := range s {
+		fmt.Printf("attack=%s success=%d failures=%d avg=%dms p99=%dms\n", e.Attack, e.Results.PRes.Success_Count, e.Results.PRes.Error_Count, e.Results.PRes.ART.Milliseconds(), e.Results.PRes.P99.Milliseconds())
+	}
+}
+
+func printVerbose(attacks []common.PlotC) {
+	fmt.Println("🚀 Suzi Load Test Result")
+	fmt.Println("────────────────────────────────")
+
+	for _, e := range attacks {
+		fmt.Printf("Attack Type    : %s\n", e.Attack)
+
+		fmt.Printf("Total Requests : %d\n",
+			e.Results.PRes.Success_Count+e.Results.PRes.Error_Count)
+
+		fmt.Printf("Successful     : %d\n", e.Results.PRes.Success_Count)
+		fmt.Printf("Failed         : %d\n", e.Results.PRes.Error_Count)
+
+		fmt.Printf("Avg Latency    : %v\n", e.Results.PRes.ART)
+		fmt.Printf("p50 Latency    : %v\n", e.Results.PRes.P50)
+		fmt.Printf("p90 Latency    : %v\n", e.Results.PRes.P90)
+		fmt.Printf("p95 Latency    : %v\n", e.Results.PRes.P95)
+		fmt.Printf("P99 Latency    : %v\n", e.Results.PRes.P99)
+		fmt.Println("────────────────────────────────")
+
+		fmt.Println()
+	}
+}
+
+func printVerboseHeader(opts attacks.Options) {
+	fmt.Println("🚀 Suzi Load Test")
+	fmt.Println("────────────────────────────")
+	fmt.Printf("Target        %s\n", opts.URL)
+	fmt.Printf("Method        %s\n", opts.Method)
+	fmt.Printf("Rate          %d req/s\n", opts.Rate)
+	fmt.Printf("Requests      %d\n", opts.Requests)
+	fmt.Printf("Timeout       %s\n", opts.Timeout)
+
+	if string(opts.Body) != "" {
+		fmt.Printf("Body          %s\n", string(opts.Body))
+	}
+
+	if opts.EmailEnabled {
+		fmt.Println("Email Alerts  ENABLED")
+	} else {
+		fmt.Println("Email Alerts  DISABLED")
+	}
+
+	fmt.Println("────────────────────────────")
+	fmt.Println()
+}
+
+func printDefault(attacks []common.PlotC) {
+	for _, e := range attacks {
+		fmt.Printf("Attack: %s\n", e.Attack)
+
+		total := e.Results.PRes.Success_Count + e.Results.PRes.Error_Count
+
+		fmt.Printf("  Requests : %d\n", total)
+		fmt.Printf("  Success  : %d\n", e.Results.PRes.Success_Count)
+		fmt.Printf("  Failures : %d\n", e.Results.PRes.Error_Count)
+		fmt.Printf("  Avg      : %v\n", e.Results.PRes.ART)
+		fmt.Printf("  P99      : %v\n", e.Results.PRes.P99)
+
+		fmt.Println()
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,14 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/spf13/cobra"
 )
 
-var (
-	verbose bool
-)
+var debug bool
 
 // rootCmd is the base command for the CLI.
 var rootCmd = &cobra.Command{
@@ -19,6 +18,10 @@ var rootCmd = &cobra.Command{
 
 It supports multiple attack strategies (constant, ramp, burst, custom patterns),
 result summarization, and integrations (mail, dashboards).`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		setupLogger()
+		return nil
+	},
 
 	// Root command should NOT run any attack directly.
 	// It should only show help if called without subcommands.
@@ -36,6 +39,23 @@ func Execute() {
 }
 
 func init() {
-	// Global flags available to all subcommands
-	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
+	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable debug logging")
+}
+
+func DebugEnabled() bool {
+	return debug
+}
+
+func setupLogger() {
+	level := slog.LevelInfo
+
+	if DebugEnabled() {
+		level = slog.LevelDebug
+	}
+
+	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: level,
+	})
+
+	slog.SetDefault(slog.New(handler))
 }

--- a/core/calculate.go
+++ b/core/calculate.go
@@ -1,0 +1,14 @@
+package core
+
+import "time"
+
+func percentileCalculation(latencies []time.Duration, p float64) time.Duration {
+	if len(latencies) == 0 {
+		return 0
+	}
+	index := int((p / 100.0) * float64(len(latencies)))
+	if index >= len(latencies) {
+		index = len(latencies) - 1
+	}
+	return latencies[index]
+}

--- a/core/show.go
+++ b/core/show.go
@@ -1,23 +1,12 @@
 package core
 
 import (
-	"fmt"
+	"log/slog"
 	"sort"
 	"time"
 
 	rs "github.com/Mujib-Ahasan/Suzi/common"
 )
-
-func percentileCalculation(latencies []time.Duration, p float64) time.Duration {
-	if len(latencies) == 0 {
-		return 0
-	}
-	index := int((p / 100.0) * float64(len(latencies)))
-	if index >= len(latencies) {
-		index = len(latencies) - 1
-	}
-	return latencies[index]
-}
 
 func ShowResults(results []rs.Result, numRequests int, attack string, method string) rs.InResult {
 	var totalTime time.Duration
@@ -27,11 +16,10 @@ func ShowResults(results []rs.Result, numRequests int, attack string, method str
 	latencies := make([]time.Duration, 0, successCount)
 	for _, r := range results {
 		if r.Error != nil {
-			fmt.Println("Error:", r.Error)
 			errorCount++
 		} else {
-			fmt.Println("Response Status:", r.Status)
-			fmt.Println("Response Time:", r.Elapsed)
+			slog.Debug("Response Status:", r.Status)
+			slog.Debug("Response Time:", r.Elapsed)
 			totalTime += r.Elapsed
 			successCount++
 			latencies = append(latencies, r.Elapsed)

--- a/mail/mailFunc.go
+++ b/mail/mailFunc.go
@@ -26,7 +26,7 @@ func (cfg *Config) SendMail(emailTo string, reportHTML string) error {
 	if err := m.Send(ctx, recipients, "Suzi Load Test Report", html, text); err != nil {
 		return fmt.Errorf("email send failed: %w ", err)
 	} else {
-		fmt.Println("email sent successfully!!!")
+		fmt.Println("Email sent successfully")
 	}
 
 	return nil


### PR DESCRIPTION
Introduces `--quiet` and `--verbose` flags to clearly separate machine-friendly and human-friendly CLI output.
Adds a `--debug` flag using slog for structured developer logs.
Output modes are mutually exclusive and backward compatibility is preserved.

close #12 