### PR TITLE
Feature: `generate` subcommand and `apply --set` flag added.

### DIFF
--- a/internal/cli/apply_generate.go
+++ b/internal/cli/apply_generate.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var attackGenerateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "Generate a yaml file from attack configuration",
+	Long: `Generate a yaml file from attack configuration.
+
+This is not like ordinary attack command but generate a attack yaml
+file from the attack configuration`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		currentAttack.AttackMethod = strings.ToUpper(currentAttack.AttackMethod)
+
+		err := currentAttack.ValidateMethod()
+		if err != nil {
+			return err
+		}
+
+		err = currentAttack.ValidateBeforeAttack()
+		if err != nil {
+			return err
+		}
+
+		currentAttack.AttackContentType, err = ValidateContentType(currentAttack.AttackContentType)
+		if err != nil {
+			return err
+		}
+		var payload []byte
+		if currentAttack.AttackBodyFile != "" || currentAttack.AttackBody != "" {
+			payload, err = currentAttack.ValidateBody()
+			currentAttack.AttackBody = string(payload)
+			currentAttack.AttackBodyFile = ""
+		}
+
+		if currentAttack.EmailBool {
+			currentAttack.Email = &EmailConfig{}
+			currentAttack.Email.To = currentAttack.EmailTo
+			currentAttack.Email.From = currentAttack.EmailFrom
+			currentAttack.Email.SMTP.Host = currentAttack.SmtpHost
+			currentAttack.Email.SMTP.Port = currentAttack.SmtpPort
+			currentAttack.Email.SMTP.Retries = currentAttack.SmtpRetries
+			currentAttack.Email.SMTP.TimeoutSeconds = currentAttack.SmtpTimeoutS
+			currentAttack.Email.SMTP.TLS = currentAttack.SmtpTLS
+
+			err = currentAttack.Email.Validate()
+			if err != nil {
+				return err
+			}
+		}
+
+		if output == "" {
+			if err := WriteYAMLToStdout(currentAttack); err != nil {
+				return err
+			}
+		} else {
+			if err := WriteToYAML(currentAttack, output); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	attackCmd.AddCommand(attackGenerateCmd)
+
+	attackGenerateCmd.Flags().StringVar(&currentAttack.AttackURL, "url", "", "Target URL for the attack (required)")
+	attackGenerateCmd.Flags().IntVar(&currentAttack.AttackRate, "rate", 5, "Requests per second")
+	attackGenerateCmd.Flags().IntVar(&currentAttack.AttackReq, "req", 25, "Total number of requests to send")
+	attackGenerateCmd.Flags().StringVar(&currentAttack.AttackMethod, "method", "GET", "HTTP method (GET, POST, PUT, DELETE, etc.)")
+	attackGenerateCmd.Flags().StringVar(&currentAttack.AttackBody, "body", "", "Inline POST body")
+	attackGenerateCmd.Flags().StringVar(&currentAttack.AttackBodyFile, "body-file", "", "Read POST body from file")
+	attackGenerateCmd.Flags().StringVar(&currentAttack.AttackContentType, "content-type", "", "Attack content type")
+	attackGenerateCmd.Flags().StringVar(&currentAttack.Header, "header", "", "Headers for the request")
+	attackGenerateCmd.Flags().StringVar(&currentAttack.AttackType, "attack-type", "basic", "Type of attack (basic/burst/rampup/random)")
+	attackGenerateCmd.Flags().BoolVar(&currentAttack.EmailBool, "email", false, "Email Enable or not")
+
+	attackGenerateCmd.Flags().StringVar(&currentAttack.EmailTo, "emailto", "you@local.test", "Comma-separated list of recipients")
+	attackGenerateCmd.Flags().StringVar(&currentAttack.SmtpHost, "smtpHost", "localhost", "SMTP host (e.g. smtp.gmail.com)")
+	attackGenerateCmd.Flags().IntVar(&currentAttack.SmtpPort, "smtpPort", 1025, "SMTP port (e.g. 587 or 465)")
+	attackGenerateCmd.Flags().StringVar(&currentAttack.SmtpUser, "smtp-user", os.Getenv("SMTP_USER"), "SMTP username (default from env SMTP_USER)")
+	attackGenerateCmd.Flags().StringVar(&currentAttack.SmtpPass, "smtp-pass", os.Getenv("SMTP_PASS"), "SMTP password/app password (default from env SMTP_PASS)")
+	attackGenerateCmd.Flags().StringVar(&currentAttack.EmailFrom, "emailFrom", "Suzi <noreply@gmail.com>", "From header")
+	attackGenerateCmd.Flags().BoolVar(&currentAttack.SmtpTLS, "smtpTLS", false, "Use TLS (SMTPS/STARTTLS)")
+	attackGenerateCmd.Flags().IntVar(&currentAttack.SmtpRetries, "smtp-retries", 3, "Email send retries")
+	attackGenerateCmd.Flags().IntVar(&currentAttack.SmtpTimeoutS, "smtp-timeout", 10, "Email send timeout in seconds")
+}

--- a/internal/cli/attack.go
+++ b/internal/cli/attack.go
@@ -28,7 +28,7 @@ func init() {
 	rootCmd.AddCommand(attackCmd)
 
 	attackCmd.PersistentFlags().BoolVar(&quiet, "quiet", false, "machine-friendly output")
-	attackCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "human-friendly output")
+	attackCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "human-friendly output")
 	attackCmd.PersistentFlags().StringVar(&format, "format", "text", "Format could be JSON, YAML")
 	attackCmd.PersistentFlags().StringVar(&output, "output", "", "file path where report will be stored")
 }

--- a/internal/cli/attack_apply.go
+++ b/internal/cli/attack_apply.go
@@ -20,9 +20,10 @@ import (
 )
 
 var applyFile string
+var set string
 
 // applyCmd represents the attack apply command
-var applyCmd = &cobra.Command{
+var attackApplyCmd = &cobra.Command{
 	Use:   "apply",
 	Short: "Apply an attack configuration from a YAML file",
 	Long: `Apply a load test configuration from a YAML file.
@@ -69,7 +70,7 @@ as the primary configuration source. CLI flags override YAML values.`,
 			return err
 		}
 
-		attackContentType, err := ValidateContentType(currentAttack.AttackContentType)
+		attackContentType, err := ValidateContentType(cfg.AttackContentType)
 		if err != nil {
 			return err
 		}
@@ -78,6 +79,8 @@ as the primary configuration source. CLI flags override YAML values.`,
 		if cfg.Email != nil {
 			emailFlag = true
 		}
+		header := cfg.ValidateHeader()
+		// err = cfg.SetValue(set)
 
 		opts := attacks.Options{
 			URL:          cfg.AttackURL,
@@ -88,6 +91,7 @@ as the primary configuration source. CLI flags override YAML values.`,
 			Method:       cfg.AttackMethod,
 			Body:         payload,
 			ContentType:  attackContentType,
+			Headers:      header,
 			EmailEnabled: emailFlag,
 		}
 
@@ -168,9 +172,10 @@ as the primary configuration source. CLI flags override YAML values.`,
 }
 
 func init() {
-	applyCmd.Flags().StringVarP(&applyFile, "file", "f", "", "Path to attack YAML file")
+	attackApplyCmd.Flags().StringVarP(&applyFile, "file", "f", "", "Path to attack YAML file")
+	attackApplyCmd.Flags().StringVar(&set, "set", "", "override values then apply")
 
-	attackCmd.AddCommand(applyCmd)
+	attackCmd.AddCommand(attackApplyCmd)
 }
 
 func loadAttackFromYAML(path string) (*Attack, error) {
@@ -296,3 +301,27 @@ func DecodeStrictYAML(path string, out any) error {
 
 	return nil
 }
+
+// func (current *Attack) SetValue(set string) error {
+// 	fmt.Printf("%s \n", set)
+
+// 	set = strings.TrimSpace(set)
+// 	// setMap := make(map[string]string)
+// 	pairs := strings.Split(set, ",")
+// 	fmt.Println(pairs)
+
+// 	for _, pair := range pairs {
+// 		parts := strings.SplitN(pair, "=", 2)
+// 		if len(parts) == 2 {
+// 			key := strings.TrimSpace(parts[0])
+// 			value := strings.TrimSpace(parts[1])
+
+// 			fmt.Printf("%s: %s \n", key, value)
+// 		}
+// 	}
+
+// 	os.Exit(1)
+
+// 	return nil
+
+// }

--- a/internal/cli/attack_apply.go
+++ b/internal/cli/attack_apply.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -51,8 +53,11 @@ as the primary configuration source. CLI flags override YAML values.`,
 		if err != nil {
 			return err
 		}
+		err = cfg.SetValue(set)
+		if err != nil {
+			return err
+		}
 		cfg.AttackMethod = strings.ToUpper(cfg.AttackMethod)
-
 		if err := cfg.ValidateYaml(); err != nil {
 			return err
 		}
@@ -61,10 +66,12 @@ as the primary configuration source. CLI flags override YAML values.`,
 		if err != nil {
 			return err
 		}
+
 		err = cfg.ValidateBeforeAttack()
 		if err != nil {
 			return err
 		}
+
 		payload, err := cfg.ValidateBody()
 		if err != nil {
 			return err
@@ -80,7 +87,6 @@ as the primary configuration source. CLI flags override YAML values.`,
 			emailFlag = true
 		}
 		header := cfg.ValidateHeader()
-		// err = cfg.SetValue(set)
 
 		opts := attacks.Options{
 			URL:          cfg.AttackURL,
@@ -302,26 +308,79 @@ func DecodeStrictYAML(path string, out any) error {
 	return nil
 }
 
-// func (current *Attack) SetValue(set string) error {
-// 	fmt.Printf("%s \n", set)
+func (current *Attack) SetValue(set string) error {
+	set = strings.TrimSpace(set)
+	pairs := strings.Split(set, ",")
+	val := reflect.ValueOf(current).Elem()
+	typ := val.Type()
 
-// 	set = strings.TrimSpace(set)
-// 	// setMap := make(map[string]string)
-// 	pairs := strings.Split(set, ",")
-// 	fmt.Println(pairs)
+	for _, pair := range pairs {
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) == 2 {
+			key := strings.TrimSpace(parts[0])
+			value := strings.TrimSpace(parts[1])
 
-// 	for _, pair := range pairs {
-// 		parts := strings.SplitN(pair, "=", 2)
-// 		if len(parts) == 2 {
-// 			key := strings.TrimSpace(parts[0])
-// 			value := strings.TrimSpace(parts[1])
+			for i := 0; i < typ.NumField(); i++ {
+				typeOfField := typ.Field(i)
+				yamltag := typeOfField.Tag.Get("yaml")
 
-// 			fmt.Printf("%s: %s \n", key, value)
-// 		}
-// 	}
+				tagName := strings.Split(yamltag, ",")[0]
 
-// 	os.Exit(1)
+				if tagName == "-" || tagName == "" {
+					continue
+				}
 
-// 	return nil
+				if tagName == key {
+					field := val.Field(i)
+					if !field.CanSet() {
+						return fmt.Errorf("cannot set the value of Field: %s", typeOfField.Name)
+					}
+					//seting the filed value
+					if err := setValue(field, value); err != nil {
+						return fmt.Errorf("failed setting %s: %w", key, err)
+					}
 
-// }
+				}
+			}
+		}
+	}
+
+	return nil
+
+}
+
+func setValue(field reflect.Value, value string) error {
+
+	switch field.Kind() {
+	case reflect.String:
+		field.SetString(value)
+	case reflect.Int, reflect.Int64, reflect.Int32:
+		if field.Type() == reflect.TypeOf(time.Duration(0)) {
+			d, err := time.ParseDuration(value)
+			if err != nil {
+				return err
+			}
+			field.SetInt(int64(d))
+			return nil
+		}
+
+		intVal, err := strconv.Atoi(value)
+		if err != nil {
+			return err
+		}
+		field.SetInt(int64(intVal))
+
+	case reflect.Bool:
+		b, err := strconv.ParseBool(value)
+		if err != nil {
+			return err
+		}
+		field.SetBool(b)
+
+	default:
+		return fmt.Errorf("Unsupported field type: %s", field.Kind())
+
+	}
+
+	return nil
+}

--- a/internal/cli/attack_run.go
+++ b/internal/cli/attack_run.go
@@ -54,7 +54,7 @@ Example:
 			return err
 		}
 
-		attackContentType, err := ValidateContentType(currentAttack.AttackContentType)
+		currentAttack.AttackContentType, err = ValidateContentType(currentAttack.AttackContentType)
 		if err != nil {
 			return err
 		}
@@ -69,7 +69,7 @@ Example:
 			Type:         currentAttack.AttackType,
 			Method:       currentAttack.AttackMethod,
 			Body:         payload,
-			ContentType:  attackContentType,
+			ContentType:  currentAttack.AttackContentType,
 			Headers:      header,
 			EmailEnabled: false,
 		}

--- a/internal/cli/datastructure.go
+++ b/internal/cli/datastructure.go
@@ -6,13 +6,14 @@ type Attack struct {
 	AttackURL         string        `yaml:"url"`
 	AttackRate        int           `yaml:"rate"`
 	AttackReq         int           `yaml:"requests"`
-	AttackTimeout     time.Duration `yaml:"timeout"`
+	AttackTimeout     time.Duration `yaml:"timeout,omitempty"`
 	AttackType        string        `yaml:"attack-type"`
 	AttackMethod      string        `yaml:"method"`
-	AttackBody        string        `yaml:"body"`
-	AttackBodyFile    string        `yaml:"body-file"`
-	AttackContentType string        `yaml:"content-type"`
-	Header            string        `yaml:"header"`
+	AttackBody        string        `yaml:"body,omitempty"`
+	AttackBodyFile    string        `yaml:"body-file,omitempty"`
+	AttackContentType string        `yaml:"content-type,omitempty"`
+	Header            string        `yaml:"header,omitempty"`
+	EmailBool         bool          `yaml:"emailEnable"`
 	Email             *EmailConfig  `yaml:"email,omitempty"`
 	EmailTo           string        `yaml:"-"`
 	SmtpHost          string        `yaml:"-"`
@@ -28,15 +29,15 @@ type Attack struct {
 type EmailConfig struct {
 	To   string     `yaml:"to"`
 	From string     `yaml:"from"`
-	SMTP SMTPConfig `yaml:"smtp"`
+	SMTP SMTPConfig `yaml:"smtp,omitempty"`
 }
 
 type SMTPConfig struct {
-	Host           string `yaml:"host"`
-	Port           int    `yaml:"port"`
-	User           string `yaml:"user"`
-	Pass           string `yaml:"pass"`
-	TLS            bool   `yaml:"tls"`
-	Retries        int    `yaml:"retries"`
-	TimeoutSeconds int    `yaml:"timeout_seconds"`
+	Host           string `yaml:"host,omitempty"`
+	Port           int    `yaml:"port,omitempty"`
+	User           string `yaml:"user,omitempty"`
+	Pass           string `yaml:"pass,omitempty"`
+	TLS            bool   `yaml:"tls,omitempty"`
+	Retries        int    `yaml:"retries,omitempty"`
+	TimeoutSeconds int    `yaml:"timeout_seconds,omitempty"`
 }

--- a/internal/cli/datastructure_utils.go
+++ b/internal/cli/datastructure_utils.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+func WriteToYAML(currentAttack Attack, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	enc := yaml.NewEncoder(f)
+	enc.SetIndent(2)
+	defer enc.Close()
+
+	return enc.Encode(currentAttack)
+}
+
+func WriteYAMLToStdout(currentAttack Attack) error {
+	enc := yaml.NewEncoder(os.Stdout)
+	enc.SetIndent(2)
+	defer enc.Close()
+
+	return enc.Encode(currentAttack)
+}


### PR DESCRIPTION
# Description
- Subcommand `generate` subcommand added for suzi cli. It is added so that cli command can easily be converted to yaml file which we can store and apply next time.
`suzi attack generate [flags]`
- `--set` flag added to apply subcommand so one can easily perform attack by setting in the cli.
 ` suzi attack apply -f <file_path> --set key1=val1,key2=val2` (here key1 and key2 must be fields in yaml schema`

closes #17 